### PR TITLE
SHARD-1858: don't allow for custom object to be passed into Buffer.from

### DIFF
--- a/src/utils/functions/stringify.ts
+++ b/src/utils/functions/stringify.ts
@@ -168,7 +168,7 @@ function stringifyHelper(
 function getBufferFromField(input: any, encoding?: 'base64'): Buffer {
   if (encoding === 'base64' && typeof input.value !== 'object') {
     return Buffer.from(input.value, 'base64')
-  } else if (typeof input.value !== 'object') {
+  } else if (typeof input !== 'object') {
     return Buffer.from(input)
   } else {
     return input

--- a/src/utils/functions/stringify.ts
+++ b/src/utils/functions/stringify.ts
@@ -61,7 +61,8 @@ function isBufferValue(toStr: unknown, val: Record<string, unknown>): boolean {
     toStr === '[object Object]' &&
     objKeys(val).length === 2 &&
     objKeys(val).includes('type') &&
-    val['type'] === 'Buffer'
+    val['type'] === 'Buffer' && 
+    typeof val.data !== 'object' // avoid Buffer.from({type: 'Buffer', data: {0: 1, 1:1, 2:2, length:4294967295}) vulnerability
   )
 }
 
@@ -165,11 +166,12 @@ function stringifyHelper(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getBufferFromField(input: any, encoding?: 'base64'): Buffer {
-  switch (encoding) {
-    case 'base64':
-      return Buffer.from(input.value, 'base64')
-    default:
-      return Buffer.from(input)
+  if (encoding === 'base64' && typeof input.value !== 'object') {
+    return Buffer.from(input.value, 'base64')
+  } else if (typeof input.value !== 'object') {
+    return Buffer.from(input)
+  } else {
+    return input
   }
 }
 
@@ -182,6 +184,9 @@ function getBufferFromField(input: any, encoding?: 'base64'): Buffer {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function typeReviver(key: string, value: any): any {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined;
+  }
   if (key === 'sig') return value
   const originalObject = value
   if (
@@ -193,9 +198,13 @@ export function typeReviver(key: string, value: any): any {
       if (typeof originalObject.value !== 'string') {
         return value
       }
-      return originalObject.dataType === 'bb'
-        ? getBufferFromField(originalObject, 'base64')
-        : Uint8Array.from(Buffer.from(originalObject.value, 'base64'))
+      if (originalObject.dataType === 'bb') {
+        return getBufferFromField(originalObject, 'base64')
+      } else if (typeof originalObject.value !== 'object') {
+        return Uint8Array.from(Buffer.from(originalObject.value, 'base64'))
+      } else {
+        return originalObject.value
+      }
     } else if (originalObject.dataType === 'bi') {
       return BigInt('0x' + originalObject.value)
     } else {

--- a/src/utils/functions/stringify.ts
+++ b/src/utils/functions/stringify.ts
@@ -61,8 +61,27 @@ function isBufferValue(toStr: unknown, val: Record<string, unknown>): boolean {
     toStr === '[object Object]' &&
     objKeys(val).length === 2 &&
     objKeys(val).includes('type') &&
-    val['type'] === 'Buffer' && 
-    typeof val.data !== 'object' // avoid Buffer.from({type: 'Buffer', data: {0: 1, 1:1, 2:2, length:4294967295}) vulnerability
+    val['type'] === 'Buffer' &&
+    isSafeForBuffer(val.data)
+  )
+}
+
+function isSafeForBuffer(val: unknown): boolean {
+  // avoid Buffer.from({type: 'Buffer', data: {0: 1, 1:1, 2:2, length:4294967295}) vulnerability
+  return (
+    typeof val === 'string' ||
+    Array.isArray(val) ||
+    Buffer.isBuffer(val) ||
+    val instanceof Uint8Array ||
+    val instanceof Int8Array ||
+    val instanceof Uint16Array ||
+    val instanceof Int16Array ||
+    val instanceof Uint32Array ||
+    val instanceof Int32Array ||
+    val instanceof Float32Array ||
+    val instanceof Float64Array ||
+    val instanceof BigInt64Array ||
+    val instanceof BigUint64Array
   )
 }
 
@@ -166,9 +185,9 @@ function stringifyHelper(
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getBufferFromField(input: any, encoding?: 'base64'): Buffer {
-  if (encoding === 'base64' && typeof input.value !== 'object') {
+  if (encoding === 'base64' && isSafeForBuffer(input.value)) {
     return Buffer.from(input.value, 'base64')
-  } else if (typeof input !== 'object') {
+  } else if (isSafeForBuffer(input)) {
     return Buffer.from(input)
   } else {
     return input
@@ -185,7 +204,7 @@ function getBufferFromField(input: any, encoding?: 'base64'): Buffer {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function typeReviver(key: string, value: any): any {
   if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-    return undefined;
+    return undefined
   }
   if (key === 'sig') return value
   const originalObject = value
@@ -200,7 +219,7 @@ export function typeReviver(key: string, value: any): any {
       }
       if (originalObject.dataType === 'bb') {
         return getBufferFromField(originalObject, 'base64')
-      } else if (typeof originalObject.value !== 'object') {
+      } else if (isSafeForBuffer(originalObject.value)) {
         return Uint8Array.from(Buffer.from(originalObject.value, 'base64'))
       } else {
         return originalObject.value

--- a/test/src/utils/functions/stringify.test.ts
+++ b/test/src/utils/functions/stringify.test.ts
@@ -295,6 +295,57 @@ describe('safeJsonParse', function () {
     })
   })
 
+  it('parses JSON string with Buffer and BigInt', () => {
+    const buffer = Buffer.from('hello')
+    const obj = {
+      buf: buffer,
+      bigint: BigInt(100),
+    }
+    expect(safeJsonParse(safeStringify(obj))).toEqual({
+      buf: buffer,
+      bigint: BigInt(100),
+    })
+  })
+
+  it('prevents overflow with object pretending to be Buffer', () => {
+    const maliciousObj = {
+      type: 'Buffer',
+      data: { length: 4294967295 }, // Simulating a huge object
+    }
+    expect(safeJsonParse(JSON.stringify(maliciousObj))).toEqual({
+      type: 'Buffer',
+      data: { length: 4294967295 },
+    });
+  })
+
+  it('prevents overflow with fake array-like object', () => {
+    const fakeArray = { 0: 'H', 1: 'i', length: 4294967295 }
+    expect(safeJsonParse(JSON.stringify(fakeArray))).toEqual({
+       0: 'H', 1: 'i', length: 4294967295
+    });
+  })
+
+  it('handles valid base64 buffer encoding safely', () => {
+    const originalBuffer = Buffer.from('test-data')
+    const encoded = safeStringify({ buf: originalBuffer })
+    const decoded = safeJsonParse(encoded)
+
+    expect(decoded.buf).toEqual(originalBuffer)
+  })
+
+  it('handles Uint8Array safely', () => {
+    const uint8 = new Uint8Array([72, 101, 108, 108, 111])
+    const obj = { uint8 }
+    expect(safeJsonParse(safeStringify(obj))).toEqual(obj)
+  })
+
+  it('prevents prototype pollution attack', () => {
+    const maliciousPayload = '{"__proto__":{"polluted":true}}'
+    const parsed = safeJsonParse(maliciousPayload)
+
+    expect(parsed.polluted).toBeUndefined()
+  })
+
   it('parses JSON string with nested structures', () => {
     const nestedJson = '{"a": {"b": {"c": [1, 2, {"d": "test"}]}}}'
     const nestedObject = { a: { b: { c: [1, 2, { d: 'test' }] } } }


### PR DESCRIPTION
**Description:**

This PR improves security and memory safety in stringify.ts by addressing potential OOM risks and prototype pollution vulnerabilities in getBufferFromField, typeReviver, and isBufferValue.

Reason: Prevents a potential ```Buffer.from({ type: 'Buffer', data: { 0: 1, ..., length: 4294967295 } })``` attack.

✅ Summary of Fixes
	•	🛡 OOM protection: Ensures Buffer.from() only processes valid base64 strings, avoiding large allocations.
	•	🛡 Prototype pollution fix: Blocks __proto__, constructor, and prototype keys.
	•	🛡 Safer buffer decoding: Prevents typeReviver from misinterpreting large objects as base64.
